### PR TITLE
#9, Link stack and jump functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,53 @@ augroup vimsidian_augroup
 </details>
 <!--}}}-->
 
+<!--{{{Use link stack -->
+
+<details open>
+<summary>Use link stack</summary>
+
+Keep a stack of link jump history in each window (w:w:vimsidian_link_stack)
+Provides jump and jumpback functionality to entries in the link stack.
+Like CTRL+t/CTRL+] for tags using ctags in vim.
+
+Detials: <https://github.com/kis9a/vimsidian/pull/9>, <https://github.com/kis9a/vimsidian/issues/9>
+
+```vim
+let g:vimsidian_enable_link_stack = 1
+
+" example
+augroup vimsidian_augroup
+  au!
+  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> <buffer> <C-]> :VimsidianMoveToNextEntryInLinkStack<CR>
+  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> <buffer> <C-t> :VimsidianMoveToPreviousEntryInLinkStack<CR>
+  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> <buffer> S :VimsidianLinkStack<CR>
+" ry ...
+```
+
+</details>
+<!--}}}-->
+
+<!--{{{ Use fzf to list note names -->
+<details open>
+<summary>Use fzf to list note names</summary>
+<br/>
+
+Open listings using fzf instead of quick fix window.
+See fzf installation at <https://github.com/junegunn/fzf.vim#installation>
+
+```vim
+# e.g
+Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
+Plug 'junegunn/fzf.vim'
+
+if executable('fzf')
+  let g:vimsidian_use_fzf = 1
+endif
+```
+
+</details>
+<!--}}}-->
+
 <!--{{{ Change link open mode -->
 <details close>
 <summary>Change link open mode</summary>
@@ -138,27 +185,6 @@ let g:vimsidian_link_open_mode = 'vnew'
 
 " hsplit
 let g:vimsidian_link_open_mode = 'new'
-```
-
-</details>
-<!--}}}-->
-
-<!--{{{ Use fzf to list note names -->
-<details close>
-<summary>Use fzf to list note names</summary>
-<br/>
-
-Open listings using fzf instead of quick fix window.
-See fzf installation at <https://github.com/junegunn/fzf.vim#installation>
-
-```vim
-# e.g
-Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
-Plug 'junegunn/fzf.vim'
-
-if executable('fzf')
-  let g:vimsidian_use_fzf = 1
-endif
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ For me, [vimsidian](https://github.com/kis9a/vimsidian) is the plugin that solve
 - Default syntax highlighting settings.
 - Custom formatting of link spacing.
 - Manage multiple `g:vimsidian_path` (Obsidian Vault).
+- Stack of link jump history in .
 - Daily note feature.
 - Highlighting broken links.
 - Fewer dependencies.
@@ -124,21 +125,22 @@ augroup vimsidian_augroup
 <details open>
 <summary>Use link stack</summary>
 
-Keep a stack of link jump history in each window (w:vimsidian_link_stack)
-Provides jump and jumpback functionality to entries in the link stack.
-Like CTRL+t/CTRL+] for tags using ctags in vim.
+Keep a stack of link jump history in each window (w:vimsidian_link_stack)  
+Provides jump and jumpback functionality to entries in the link stack.  
+Like CTRL+t/CTRL+] for tags using ctags in vim. (:h tags)
 
 Detials: <https://github.com/kis9a/vimsidian/pull/10>, <https://github.com/kis9a/vimsidian/issues/9>
 
 ```vim
 let g:vimsidian_enable_link_stack = 1
 
-" example
+" Example mapping like ctags jump
 augroup vimsidian_augroup
   au!
-  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> <buffer> <C-]> :VimsidianMoveToNextEntryInLinkStack<CR>
-  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> <buffer> <C-t> :VimsidianMoveToPreviousEntryInLinkStack<CR>
-  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> <buffer> S :VimsidianLinkStack<CR>
+  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <buffer> <C-]> :VimsidianMoveToLink<CR>
+  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> <C-t> :VimsidianMoveToPreviousEntryInLinkStack<CR>
+  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> sn :VimsidianMoveToNextEntryInLinkStack<CR>
+  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> ss :VimsidianLinkStack<CR>
 " ry ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ augroup vimsidian_augroup
 <details open>
 <summary>Use link stack</summary>
 
-Keep a stack of link jump history in each window (w:w:vimsidian_link_stack)
+Keep a stack of link jump history in each window (w:vimsidian_link_stack)
 Provides jump and jumpback functionality to entries in the link stack.
 Like CTRL+t/CTRL+] for tags using ctags in vim.
 
-Detials: <https://github.com/kis9a/vimsidian/pull/9>, <https://github.com/kis9a/vimsidian/issues/9>
+Detials: <https://github.com/kis9a/vimsidian/pull/10>, <https://github.com/kis9a/vimsidian/issues/9>
 
 ```vim
 let g:vimsidian_enable_link_stack = 1

--- a/autoload/vimsidian.vim
+++ b/autoload/vimsidian.vim
@@ -246,7 +246,11 @@ function! vimsidian#MoveToLink() abort
     call vimsidian#logger#Info('Linked note not found' . vimsidian#util#WrapWithSingleQuote(f . lex))
     return
   else
-    call vimsidian#action#OpenFile(g:vimsidian_link_open_mode, note)
+    if g:vimsidian_enable_link_stack
+      call vimsidian#linkStack#MoveToLink(note)
+    else
+      call vimsidian#action#OpenFile(g:vimsidian_link_open_mode, note)
+    endif
   endif
 
   let [line, col] = vimsidian#unit#InternalLinkPosition(expand('%:p'), fn)
@@ -339,6 +343,42 @@ function! vimsidian#DailyNote() abort
     endif
     call vimsidian#action#OpenFile(g:vimsidian_link_open_mode, dnote)
   endif
+endfunction
+
+function vimsidian#LinkStack()
+  call vimsidian#linkStack#Show()
+endfunction
+
+function! vimsidian#MoveToPreviousEntryInLinkStack()
+  let entry = vimsidian#linkStack#PreviousEntry()
+  if type(entry) ==# type(v:null)
+    call vimsidian#logger#Info('No previous entry in link stack')
+    return
+  endif
+
+  if vimsidian#linkStack#TypeCheckItem(entry) ==# v:null
+    call vimsidian#logger#Info('Invalid type entry ' . entry)
+    return
+  endif
+
+  call vimsidian#action#OpenFile(g:vimsidian_link_open_mode, entry['path'])
+  call cursor(entry['line'], entry['col'])
+endfunction
+
+function! vimsidian#MoveToNextEntryInLinkStack()
+  let entry = vimsidian#linkStack#NextEntry()
+  if type(entry) ==# type(v:null)
+    call vimsidian#logger#Info('No next entry in link stack')
+    return
+  endif
+
+  if vimsidian#linkStack#TypeCheckItem(entry) ==# v:null
+    call vimsidian#logger#Info('Invalid type entry ' . entry)
+    return
+  endif
+
+  call vimsidian#action#OpenFile(g:vimsidian_link_open_mode, entry['path'])
+  call cursor(entry['line'], entry['col'])
 endfunction
 
 function! vimsidian#FormatLink() abort

--- a/autoload/vimsidian.vim
+++ b/autoload/vimsidian.vim
@@ -345,11 +345,11 @@ function! vimsidian#DailyNote() abort
   endif
 endfunction
 
-function vimsidian#LinkStack()
+function! vimsidian#LinkStack() abort
   call vimsidian#linkStack#Show()
 endfunction
 
-function! vimsidian#MoveToPreviousEntryInLinkStack()
+function! vimsidian#MoveToPreviousEntryInLinkStack() abort
   let entry = vimsidian#linkStack#PreviousEntry()
   if type(entry) ==# type(v:null)
     call vimsidian#logger#Info('No previous entry in link stack')
@@ -365,7 +365,7 @@ function! vimsidian#MoveToPreviousEntryInLinkStack()
   call cursor(entry['line'], entry['col'])
 endfunction
 
-function! vimsidian#MoveToNextEntryInLinkStack()
+function! vimsidian#MoveToNextEntryInLinkStack() abort
   let entry = vimsidian#linkStack#NextEntry()
   if type(entry) ==# type(v:null)
     call vimsidian#logger#Info('No next entry in link stack')

--- a/autoload/vimsidian/linkStack.vim
+++ b/autoload/vimsidian/linkStack.vim
@@ -2,7 +2,7 @@ let w:vimsidian_link_stack = [] " list of link stack items [{ 'path': path, 'lin
 let w:vimsidian_link_stack_curidx = 0 " current index of link stack
 let s:vimsidian_link_stack_keys = ['path', 'line', 'col']
 
-function! vimsidian#linkStack#WinNew()
+function! vimsidian#linkStack#WinNew() abort
     let preWinnr = winnr('#')
     let preTabpagenr = tabpagenr('#')
 
@@ -29,7 +29,7 @@ function! vimsidian#linkStack#WinNew()
     endif
 endfunction
 
-function! vimsidian#linkStack#Push(linkStackItem)
+function! vimsidian#linkStack#Push(linkStackItem) abort
   if vimsidian#linkStack#TypeCheckItem(a:linkStackItem) ==# v:null
     return v:null
   endif
@@ -60,7 +60,7 @@ function! vimsidian#linkStack#Push(linkStackItem)
     endif
 endfunction
 
-function! vimsidian#linkStack#EqualLinkStackItem(a, b)
+function! vimsidian#linkStack#EqualLinkStackItem(a, b) abort
   for k in s:vimsidian_link_stack_keys
     if a:a[k] !=# a:b[k]
       return v:null
@@ -70,7 +70,7 @@ function! vimsidian#linkStack#EqualLinkStackItem(a, b)
   return v:true
 endfunction
 
-function! vimsidian#linkStack#TypeCheckItem(linkStackItem)
+function! vimsidian#linkStack#TypeCheckItem(linkStackItem) abort
   if type(a:linkStackItem) !=# type({})
     return v:null
   endif
@@ -84,11 +84,11 @@ function! vimsidian#linkStack#TypeCheckItem(linkStackItem)
   return v:true
 endfunction
 
-function! vimsidian#linkStack#Empty()
+function! vimsidian#linkStack#Empty() abort
   let w:vimsidian_link_stack = []
 endfunction
 
-function! vimsidian#linkStack#PopToCuridx()
+function! vimsidian#linkStack#PopToCuridx() abort
   if w:vimsidian_link_stack_curidx ==# -1
     call vimsidian#linkStack#Empty()
   else
@@ -96,12 +96,12 @@ function! vimsidian#linkStack#PopToCuridx()
   endif
 endfunction
 
-function! vimsidian#linkStack#TopCuridx()
+function! vimsidian#linkStack#TopCuridx() abort
   let linkStackIdx = len(w:vimsidian_link_stack) - 1
   let w:vimsidian_link_stack_curidx = linkStackIdx
 endfunction
 
-function! vimsidian#linkStack#IsExists()
+function! vimsidian#linkStack#IsExists() abort
   if exists('w:vimsidian_link_stack')
     return v:true
   else
@@ -109,7 +109,7 @@ function! vimsidian#linkStack#IsExists()
   endif
 endfunction
 
-function! vimsidian#linkStack#IsExistsCuridx()
+function! vimsidian#linkStack#IsExistsCuridx() abort
   if exists('w:vimsidian_link_stack_curidx')
     return v:true
   else
@@ -117,7 +117,7 @@ function! vimsidian#linkStack#IsExistsCuridx()
   endif
 endfunction
 
-function! vimsidian#linkStack#IsEmpty()
+function! vimsidian#linkStack#IsEmpty() abort
   if !exists('w:vimsidian_link_stack') || len(w:vimsidian_link_stack) ==# 0
     return v:true
   else
@@ -125,17 +125,17 @@ function! vimsidian#linkStack#IsEmpty()
   endif
 endfunction
 
-function! vimsidian#linkStack#PushCursorLink()
+function! vimsidian#linkStack#PushCursorLink() abort
   let [line, col] = vimsidian#unit#CursorLinkPosition()
   call vimsidian#linkStack#Push({ 'path': expand('%:p'), 'line': line, 'col': col })
 endfunction
 
-function! vimsidian#linkStack#MoveToLink(file)
+function! vimsidian#linkStack#MoveToLink(file) abort
   call vimsidian#linkStack#PushCursorLink()
   call vimsidian#action#OpenFile(g:vimsidian_link_open_mode, a:file)
 endfunction
 
-function! vimsidian#linkStack#PreviousEntry()
+function! vimsidian#linkStack#PreviousEntry() abort
   let linkStackIdx = len(w:vimsidian_link_stack) - 1
   if linkStackIdx ==# -1 || w:vimsidian_link_stack_curidx ==# -1
     return v:null
@@ -161,7 +161,7 @@ function! vimsidian#linkStack#PreviousEntry()
   return w:vimsidian_link_stack[w:vimsidian_link_stack_curidx + 1]
 endfunction
 
-function! vimsidian#linkStack#NextEntry()
+function! vimsidian#linkStack#NextEntry() abort
   let linkStackIdx = len(w:vimsidian_link_stack) - 1
   if linkStackIdx ==# -1 || (w:vimsidian_link_stack_curidx + 1) > linkStackIdx
     return v:null
@@ -179,7 +179,7 @@ function! vimsidian#linkStack#NextEntry()
   return w:vimsidian_link_stack[w:vimsidian_link_stack_curidx]
 endfunction
 
-function! vimsidian#linkStack#Show()
+function! vimsidian#linkStack#Show() abort
   echo '  LINE:COLUMN:PATH'
   let linkStackIdx = (len(w:vimsidian_link_stack) - 1)
 

--- a/autoload/vimsidian/linkStack.vim
+++ b/autoload/vimsidian/linkStack.vim
@@ -1,0 +1,197 @@
+let w:vimsidian_link_stack = [] " list of link stack items [{ 'path': path, 'line': line_number, 'col': column_number }]
+let w:vimsidian_link_stack_curidx = 0 " current index of link stack
+let s:vimsidian_link_stack_keys = ['path', 'line', 'col']
+
+function! vimsidian#linkStack#WinNew()
+    let preWinnr = winnr('#')
+    let preTabpagenr = tabpagenr('#')
+
+    if preWinnr !=# 0
+      let preTabpagenr = tabpagenr()
+      let preWinId = win_getid(preWinnr, preTabpagenr)
+    else
+      let preWinId = win_getid(tabpagewinnr(preTabpagenr), preTabpagenr)
+    endif
+
+    let items = gettabwinvar(preTabpagenr, preWinId, 'vimsidian_link_stack')
+    let curidx = gettabwinvar(preTabpagenr, preWinId, 'vimsidian_link_stack_curidx')
+
+    if type(items) !=# type([]) || items ==# []
+      call vimsidian#linkStack#Empty()
+    else
+      let w:vimsidian_link_stack = items
+    endif
+
+    if type(curidx) !=# type(v:t_number) || type(curidx) !=# type(v:null)
+      call vimsidian#linkStack#TopCuridx()
+    else
+      let w:vimsidian_link_stack_curidx = curidx
+    endif
+endfunction
+
+function! vimsidian#linkStack#Push(linkStackItem)
+  if vimsidian#linkStack#TypeCheckItem(a:linkStackItem) ==# v:null
+    return v:null
+  endif
+
+  if vimsidian#linkStack#IsExists() !=# v:true
+    call vimsidian#linkStack#Empty()
+  endif
+
+  if vimsidian#linkStack#IsExistsCuridx() !=# v:true
+    call vimsidian#linkStack#TopCuridx()
+  endif 
+
+  let linkStackLastIndex = (len(w:vimsidian_link_stack) - 1)
+
+  if linkStackLastIndex > w:vimsidian_link_stack_curidx
+    call vimsidian#linkStack#PopToCuridx()
+  endif
+
+  let newLinkStack = w:vimsidian_link_stack + [a:linkStackItem]
+
+  if len(w:vimsidian_link_stack) > 0 && vimsidian#linkStack#EqualLinkStackItem(w:vimsidian_link_stack[-1], a:linkStackItem)
+      call vimsidian#linkStack#TopCuridx()
+      return w:vimsidian_link_stack
+    else
+      let w:vimsidian_link_stack = newLinkStack
+      call vimsidian#linkStack#TopCuridx()
+      return w:vimsidian_link_stack
+    endif
+endfunction
+
+function! vimsidian#linkStack#EqualLinkStackItem(a, b)
+  for k in s:vimsidian_link_stack_keys
+    if a:a[k] !=# a:b[k]
+      return v:null
+    endif
+  endfor
+
+  return v:true
+endfunction
+
+function! vimsidian#linkStack#TypeCheckItem(linkStackItem)
+  if type(a:linkStackItem) !=# type({})
+    return v:null
+  endif
+
+  for k in s:vimsidian_link_stack_keys
+    if !has_key(a:linkStackItem, k)
+      return v:null
+    endif
+  endfor
+
+  return v:true
+endfunction
+
+function! vimsidian#linkStack#Empty()
+  let w:vimsidian_link_stack = []
+endfunction
+
+function! vimsidian#linkStack#PopToCuridx()
+  if w:vimsidian_link_stack_curidx ==# -1
+    call vimsidian#linkStack#Empty()
+  else
+    let w:vimsidian_link_stack = w:vimsidian_link_stack[0:w:vimsidian_link_stack_curidx]
+  endif
+endfunction
+
+function! vimsidian#linkStack#TopCuridx()
+  let linkStackIdx = len(w:vimsidian_link_stack) - 1
+  let w:vimsidian_link_stack_curidx = linkStackIdx
+endfunction
+
+function! vimsidian#linkStack#IsExists()
+  if exists('w:vimsidian_link_stack')
+    return v:true
+  else
+    return v:null
+  endif
+endfunction
+
+function! vimsidian#linkStack#IsExistsCuridx()
+  if exists('w:vimsidian_link_stack_curidx')
+    return v:true
+  else
+    return v:null
+  endif
+endfunction
+
+function! vimsidian#linkStack#IsEmpty()
+  if !exists('w:vimsidian_link_stack') || len(w:vimsidian_link_stack) ==# 0
+    return v:true
+  else
+    return v:null
+  endif
+endfunction
+
+function! vimsidian#linkStack#PushCursorLink()
+  let [line, col] = vimsidian#unit#CursorLinkPosition()
+  call vimsidian#linkStack#Push({ 'path': expand('%:p'), 'line': line, 'col': col })
+endfunction
+
+function! vimsidian#linkStack#MoveToLink(file)
+  call vimsidian#linkStack#PushCursorLink()
+  call vimsidian#action#OpenFile(g:vimsidian_link_open_mode, a:file)
+endfunction
+
+function! vimsidian#linkStack#PreviousEntry()
+  let linkStackIdx = len(w:vimsidian_link_stack) - 1
+  if linkStackIdx ==# -1 || w:vimsidian_link_stack_curidx ==# -1
+    return v:null
+  endif
+
+  let w:vimsidian_link_stack_curidx = (w:vimsidian_link_stack_curidx - 1)
+
+  let c = { 'path': expand('%:p'), 'line': line('.'), 'col': col('.') }
+
+  if linkStackIdx ==# (w:vimsidian_link_stack_curidx + 1)
+    if w:vimsidian_link_stack[-1]['path'] !=# c['path']
+      let w:vimsidian_link_stack = w:vimsidian_link_stack + [c]
+    else
+      let w:vimsidian_link_stack = w:vimsidian_link_stack[0:-2] + [c]
+    endif
+  endif
+
+  let samePos = vimsidian#linkStack#EqualLinkStackItem(w:vimsidian_link_stack[w:vimsidian_link_stack_curidx + 1], c)
+  if samePos ==# v:true && w:vimsidian_link_stack_curidx > -1
+    let w:vimsidian_link_stack_curidx = (w:vimsidian_link_stack_curidx - 1)
+  endif
+
+  return w:vimsidian_link_stack[w:vimsidian_link_stack_curidx + 1]
+endfunction
+
+function! vimsidian#linkStack#NextEntry()
+  let linkStackIdx = len(w:vimsidian_link_stack) - 1
+  if linkStackIdx ==# -1 || (w:vimsidian_link_stack_curidx + 1) > linkStackIdx
+    return v:null
+  endif
+
+  let w:vimsidian_link_stack_curidx = (w:vimsidian_link_stack_curidx + 1)
+
+  let c = { 'path': expand('%:p'), 'line': line('.'), 'col': col('.') }
+  let samePos = vimsidian#linkStack#EqualLinkStackItem(w:vimsidian_link_stack[w:vimsidian_link_stack_curidx], c)
+
+  if samePos ==# v:true && linkStackIdx >= w:vimsidian_link_stack_curidx + 1
+    let w:vimsidian_link_stack_curidx = (w:vimsidian_link_stack_curidx + 1)
+  endif
+
+  return w:vimsidian_link_stack[w:vimsidian_link_stack_curidx]
+endfunction
+
+function! vimsidian#linkStack#Show()
+  echo '  LINE:COLUMN:PATH'
+  let linkStackIdx = (len(w:vimsidian_link_stack) - 1)
+
+  for i in range(0, linkStackIdx)
+    let line = w:vimsidian_link_stack[i]['line'] . ':' . w:vimsidian_link_stack[i]['col'] . ':' . w:vimsidian_link_stack[i]['path']
+    if i ==# (w:vimsidian_link_stack_curidx + 1)
+      echo '> ' . line
+    else
+      echo '  ' . line
+    endif
+  endfor
+  if vimsidian#linkStack#IsEmpty() ==# v:true || linkStackIdx == w:vimsidian_link_stack_curidx
+    echo '> '
+  endif
+endfunction

--- a/doc/vimsidian.txt
+++ b/doc/vimsidian.txt
@@ -73,6 +73,7 @@ All options:
   |g:vimsidian_enable_syntax_highlight|
   |g:vimsidian_enable_complete_functions|
   |g:vimsidian_complete_paths_search_use_fd|
+  g:vimsidian_enable_link_stack
   |g:vimsidian_daily_note_path|
   |g:vimsidian_daily_note_template_path|
   |g:vimsidian_daily_note_date_format|
@@ -132,6 +133,15 @@ enabled by default
 
 Whether to search files under g:vimsidian_complete_paths using fd,
 use ls when 0
+
+------------------------------------------------------------------------------
+                                             *g:vimsidian_enable_link_stack*
+
+  let g:vimsidian_enable_link_stack = 1
+
+Keep a stack of link jump history in each window (w:w:vimsidian_link_stack)
+Provides jump and jumpback functionality to entries in the link stack.
+Enabled by default
 
 ------------------------------------------------------------------------------
                                                        *g:vimsidian_use_fzf*
@@ -259,6 +269,9 @@ All commands:
   |:VimsidianMoveToLink|
   |:VimsidianMoveToPreviousLink|
   |:VimsidianMoveToNextLink|
+  |:VimsidianLinkStack|
+  |:VimsidianMoveToNextEntryInLinkStack|
+  |:VimsidianMoveToPreviousEntryInLinkStack|
   |:VimsidianNewNote|
   |:VimsidianNewNoteInterfactive|
   |:VimsidianDailyNote|
@@ -341,6 +354,27 @@ Go to link before current cursor
   |:VimsidianMoveToNextLink|
 
 Go to link before current cursor
+
+------------------------------------------------------------------------------
+                                                     *vimsidian_link_stack*
+
+  |:VimsidianLinkStack|
+
+Show the contents of the link stack and the current position
+
+------------------------------------------------------------------------------
+                                *vimsidian_move_to_next_entry_in_link_stack*
+
+  |:VimsidianMoveToNextEntryInLinkStack|
+
+Move to next entry in link stack
+
+------------------------------------------------------------------------------
+                                *vimsidian_move_to_previous_entry_in_link_stack*
+
+  |:VimsidianMoveToPreviousEntryInLinkStack|
+
+Move to previous entry in link stack
 
 ------------------------------------------------------------------------------
                                                          *vimsidian_new_note*

--- a/plugin/vimsidian.vim
+++ b/plugin/vimsidian.vim
@@ -52,6 +52,10 @@ if !exists('g:vimsidian_complete_paths_search_use_fd')
   let g:vimsidian_complete_paths_search_use_fd = 1 " 0: ls, 1: fd
 endif
 
+if !exists('g:vimsidian_enable_link_stack')
+  let g:vimsidian_enable_link_stack = 1
+endif
+
 if !exists('g:vimsidian_use_fzf')
   let g:vimsidian_use_fzf = 0
 endif
@@ -126,6 +130,9 @@ command! VimsidianMoveToLink call vimsidian#MoveToLink()
 command! VimsidianMoveToCursorLink call vimsidian#MoveToCursorLink()
 command! VimsidianMoveToNextLink call vimsidian#MoveToNextLink()
 command! VimsidianMoveToPreviousLink call vimsidian#MoveToPreviousLink()
+command! VimsidianLinkStack call vimsidian#LinkStack()
+command! VimsidianMoveToNextEntryInLinkStack call vimsidian#MoveToNextEntryInLinkStack()
+command! VimsidianMoveToPreviousEntryInLinkStack call vimsidian#MoveToPreviousEntryInLinkStack()
 command! -nargs=1 VimsidianNewNote call vimsidian#NewNote(<q-args>)
 command! VimsidianNewNoteInteractive call vimsidian#NewNoteInteractive()
 command! VimsidianDailyNote call vimsidian#DailyNote()
@@ -138,6 +145,10 @@ augroup vimsidian_plugin
   au!
   if g:vimsidian_enable_complete_functions
     au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN setlocal completefunc=vimsidian#CompleteNotes
+  endif
+
+  if g:vimsidian_enable_link_stack
+    au VimEnter,WinNew $VIMSIDIAN_PATH_PATTERN call vimsidian#linkStack#WinNew()
   endif
 
   if g:vimsidian_color_definition_use_default

--- a/test/themis.vim
+++ b/test/themis.vim
@@ -256,7 +256,7 @@ function! s:suite.link_stack_push() abort
   call s:assert.equal(vimsidian#linkStack#Push(s:v1), [s:v1, s:v2, s:v1])
 endfunction
 
-function! s:suite.local_window_variable_scoped()
+function! s:suite.local_window_variable_scoped() abort
   call s:edit_A()
   let w:vimsidian_foo = ['A']
   let Atabpagenr = tabpagenr()
@@ -280,7 +280,7 @@ function! s:suite.local_window_variable_scoped()
   call s:assert.equal(gettabwinvar(Atabpagenr, Awinid, 'vimsidian_foo'), ['A'])
 endfunction
 
-function! s:suite.link_stack_winnew()
+function! s:suite.link_stack_winnew() abort
   call s:edit_A()
   let Atabpagenr = tabpagenr()
   let Awinid = win_getid()
@@ -294,13 +294,15 @@ function! s:suite.link_stack_winnew()
   call s:assert.not_equal(Atabpagenr, A1tabpagenr)
 
   call cursor(3, 1)
-  exec "let [line, col] = vimsidian#unit#CursorLinkPosition() \n let v = { 'path': expand('%:p'), 'line': line, 'col': col } \n call vimsidian#linkStack#Push(v)"
+  let [line, col] = vimsidian#unit#CursorLinkPosition()
+  let v = { 'path': expand('%:p'), 'line': line, 'col': col }
+  call vimsidian#linkStack#Push(v)
   call s:assert.equal(w:vimsidian_link_stack, [s:v1, v])
 
   call s:assert.equal(gettabwinvar(Atabpagenr, Awinid, 'vimsidian_link_stack'), [s:v1])
 endfunction
 
-function! s:suite.link_top_curidx()
+function! s:suite.link_top_curidx() abort
   let w:vimsidian_link_stack = []
   call vimsidian#linkStack#TopCuridx()
   call s:assert.equal(w:vimsidian_link_stack_curidx, -1)
@@ -316,7 +318,7 @@ function! s:suite.link_top_curidx()
   call s:assert.equal(w:vimsidian_link_stack_curidx, 3)
 endfunction
 
-function! s:suite.link_stack_pop_to_curidx()
+function! s:suite.link_stack_pop_to_curidx() abort
   let s:v1 = {'path': 'path', 'line': 3, 'col': 5}
   let w:vimsidian_link_stack = [s:v1, s:v1, s:v1]
   let w:vimsidian_link_stack_curidx = 1
@@ -329,7 +331,7 @@ function! s:suite.link_stack_pop_to_curidx()
   call s:assert.equal(w:vimsidian_link_stack, [s:v1])
 endfunction
 
-function! s:suite.link_stack_previous_entry()
+function! s:suite.link_stack_previous_entry() abort
   let s:v0 = {'path': 'path', 'line': 0, 'col': 0}
   let s:v1 = {'path': 'path', 'line': 1, 'col': 1}
   let s:v2 = {'path': 'path', 'line': 2, 'col': 2}
@@ -367,7 +369,7 @@ function! s:suite.link_stack_previous_entry()
   call s:assert.equal(vimsidian#linkStack#PreviousEntry(), v:null)
 endfunction
 
-function! s:suite.link_stack_next_entry()
+function! s:suite.link_stack_next_entry() abort
   let s:v0 = {'path': 'path', 'line': 0, 'col': 0}
   let s:v1 = {'path': 'path', 'line': 1, 'col': 1}
   let s:v2 = {'path': 'path', 'line': 2, 'col': 2}

--- a/test/themis.vim
+++ b/test/themis.vim
@@ -242,3 +242,167 @@ endfunction
 function! s:suite.remove_unsuitable_link_chars() abort
   call s:assert.equal(vimsidian#unit#RemoveUnsuitableLinkChars('a b| #^c[]'), 'a b c')
 endfunction
+
+function! s:suite.link_stack_push() abort
+  call s:assert.equal(vimsidian#linkStack#Push('string'), v:null)
+
+  let w:vimsidian_link_stack = []
+  let s:v1 = {'path': 'path', 'line': 3, 'col': 5}
+  let s:v2 = {'path': 'pathhh', 'line': 1, 'col': 2}
+  call s:assert.equal(vimsidian#linkStack#Push(s:v1), [s:v1])
+  call s:assert.equal(vimsidian#linkStack#Push(s:v1), [s:v1])
+  call s:assert.equal(vimsidian#linkStack#Push(s:v1), w:vimsidian_link_stack)
+  call s:assert.equal(vimsidian#linkStack#Push(s:v2), [s:v1, s:v2])
+  call s:assert.equal(vimsidian#linkStack#Push(s:v1), [s:v1, s:v2, s:v1])
+endfunction
+
+function! s:suite.local_window_variable_scoped()
+  call s:edit_A()
+  let w:vimsidian_foo = ['A']
+  let Atabpagenr = tabpagenr()
+  let Awinid = win_getid()
+
+  execute 'tab split'
+  if !exists('w:vimsidian_foo')
+    let w:vimsidian_foo = 'NOT EXISTS'
+  endif
+
+  call s:assert.equal(w:vimsidian_foo, 'NOT EXISTS')
+
+  execute 'tab split'
+  let w:vimsidian_foo = ['B']
+  call settabwinvar(tabpagenr(), win_getid(), 'vimsidian_foo', ['C'])
+  call s:assert.equal(w:vimsidian_foo, ['C'])
+  call s:assert.equal(gettabwinvar(Atabpagenr, Awinid, 'vimsidian_foo'), ['A'])
+
+  call add(w:vimsidian_foo, 'D')
+  call s:assert.equal(w:vimsidian_foo, ['C', 'D'])
+  call s:assert.equal(gettabwinvar(Atabpagenr, Awinid, 'vimsidian_foo'), ['A'])
+endfunction
+
+function! s:suite.link_stack_winnew()
+  call s:edit_A()
+  let Atabpagenr = tabpagenr()
+  let Awinid = win_getid()
+  let s:v1 = {'path': 'path', 'line': 3, 'col': 5}
+  let w:vimsidian_link_stack = [s:v1]
+
+  execute 'tab split'
+  let A1tabpagenr = win_getid()
+  let A1winid = win_getid()
+  call s:assert.not_equal(Awinid, A1winid)
+  call s:assert.not_equal(Atabpagenr, A1tabpagenr)
+
+  call cursor(3, 1)
+  exec "let [line, col] = vimsidian#unit#CursorLinkPosition() \n let v = { 'path': expand('%:p'), 'line': line, 'col': col } \n call vimsidian#linkStack#Push(v)"
+  call s:assert.equal(w:vimsidian_link_stack, [s:v1, v])
+
+  call s:assert.equal(gettabwinvar(Atabpagenr, Awinid, 'vimsidian_link_stack'), [s:v1])
+endfunction
+
+function! s:suite.link_top_curidx()
+  let w:vimsidian_link_stack = []
+  call vimsidian#linkStack#TopCuridx()
+  call s:assert.equal(w:vimsidian_link_stack_curidx, -1)
+
+  let s:v1 = {'path': 'path', 'line': 3, 'col': 5}
+  let w:vimsidian_link_stack = [s:v1]
+
+  call vimsidian#linkStack#TopCuridx()
+  call s:assert.equal(w:vimsidian_link_stack_curidx, 0)
+
+  let w:vimsidian_link_stack = [s:v1, s:v1, s:v1, s:v1]
+  call vimsidian#linkStack#TopCuridx()
+  call s:assert.equal(w:vimsidian_link_stack_curidx, 3)
+endfunction
+
+function! s:suite.link_stack_pop_to_curidx()
+  let s:v1 = {'path': 'path', 'line': 3, 'col': 5}
+  let w:vimsidian_link_stack = [s:v1, s:v1, s:v1]
+  let w:vimsidian_link_stack_curidx = 1
+
+  call vimsidian#linkStack#PopToCuridx()
+  call s:assert.equal(w:vimsidian_link_stack, [s:v1, s:v1])
+
+  let w:vimsidian_link_stack_curidx = 0
+  call vimsidian#linkStack#PopToCuridx()
+  call s:assert.equal(w:vimsidian_link_stack, [s:v1])
+endfunction
+
+function! s:suite.link_stack_previous_entry()
+  let s:v0 = {'path': 'path', 'line': 0, 'col': 0}
+  let s:v1 = {'path': 'path', 'line': 1, 'col': 1}
+  let s:v2 = {'path': 'path', 'line': 2, 'col': 2}
+
+  let w:vimsidian_link_stack = []
+  let w:vimsidian_link_stack_curidx = -1
+  call s:assert.equal(vimsidian#linkStack#PreviousEntry(), v:null)
+
+  let w:vimsidian_link_stack = [s:v0]
+  let w:vimsidian_link_stack_curidx = 0
+  call s:assert.equal(vimsidian#linkStack#PreviousEntry(), s:v0)
+
+  let w:vimsidian_link_stack = [s:v0]
+  let w:vimsidian_link_stack_curidx = 0
+  call s:assert.equal(vimsidian#linkStack#PreviousEntry(), s:v0)
+
+  let w:vimsidian_link_stack_curidx = -1
+  call s:assert.equal(vimsidian#linkStack#PreviousEntry(), v:null)
+
+  let w:vimsidian_link_stack = [s:v0, s:v1]
+  let w:vimsidian_link_stack_curidx = 1
+  call s:assert.equal(vimsidian#linkStack#PreviousEntry(), s:v1)
+
+  let w:vimsidian_link_stack = [s:v0, s:v1, s:v2]
+  let w:vimsidian_link_stack_curidx = 2
+  call s:assert.equal(vimsidian#linkStack#PreviousEntry(), s:v2)
+
+  let w:vimsidian_link_stack_curidx = 1
+  call s:assert.equal(vimsidian#linkStack#PreviousEntry(), s:v1)
+
+  let w:vimsidian_link_stack_curidx = 0
+  call s:assert.equal(vimsidian#linkStack#PreviousEntry(), s:v0)
+
+  let w:vimsidian_link_stack_curidx = -1
+  call s:assert.equal(vimsidian#linkStack#PreviousEntry(), v:null)
+endfunction
+
+function! s:suite.link_stack_next_entry()
+  let s:v0 = {'path': 'path', 'line': 0, 'col': 0}
+  let s:v1 = {'path': 'path', 'line': 1, 'col': 1}
+  let s:v2 = {'path': 'path', 'line': 2, 'col': 2}
+
+  let w:vimsidian_link_stack = []
+  let w:vimsidian_link_stack_curidx = -1
+  call s:assert.equal(vimsidian#linkStack#NextEntry(), v:null)
+
+  let w:vimsidian_link_stack = [s:v0]
+  let w:vimsidian_link_stack_curidx = -1
+  call s:assert.equal(vimsidian#linkStack#NextEntry(), s:v0)
+
+  let w:vimsidian_link_stack_curidx = 0
+  call s:assert.equal(vimsidian#linkStack#NextEntry(), v:null)
+
+  let w:vimsidian_link_stack = [s:v0, s:v1]
+  let w:vimsidian_link_stack_curidx = -1
+  call s:assert.equal(vimsidian#linkStack#NextEntry(), s:v0)
+
+  let w:vimsidian_link_stack_curidx = 0
+  call s:assert.equal(vimsidian#linkStack#NextEntry(), s:v1)
+
+  let w:vimsidian_link_stack_curidx = 1
+  call s:assert.equal(vimsidian#linkStack#NextEntry(), v:null)
+
+  let w:vimsidian_link_stack = [s:v0, s:v1, s:v2]
+  let w:vimsidian_link_stack_curidx = -1
+  call s:assert.equal(vimsidian#linkStack#NextEntry(), s:v0)
+
+  let w:vimsidian_link_stack_curidx = 0
+  call s:assert.equal(vimsidian#linkStack#NextEntry(), s:v1)
+
+  let w:vimsidian_link_stack_curidx = 1
+  call s:assert.equal(vimsidian#linkStack#NextEntry(), s:v2)
+
+  let w:vimsidian_link_stack_curidx = 2
+  call s:assert.equal(vimsidian#linkStack#NextEntry(), v:null)
+endfunction


### PR DESCRIPTION
## What

Keep a stack of link jump history in each window (w:vimsidian_link_stack)
Provides jump and jumpback functionality to entries in the link stack.
Like CTRL+t/CTRL+] for tags using ctags in vim.

## Issue

[Jumping back (like with ctags ctrl-t) #9](https://github.com/kis9a/vimsidian/issues/9)

## Image

![Screen Recording 2022-12-09 at 21 35 37 mov](https://user-images.githubusercontent.com/65019715/206704394-dde7db1e-5695-459b-95e5-24745a1ddd36.gif)

- Each window, tabs

![Screen Recording 2022-12-09 at 21 44 02 mov](https://user-images.githubusercontent.com/65019715/206705526-d8a9e743-9ab8-4371-a497-72142005b7b8.gif)


```vim
let g:vimsidian_enable_link_stack = 1

" example
augroup vimsidian_augroup
  au!
  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <buffer> sj :VimsidianMoveToNextLink<CR>
  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <buffer> <C-k> :VimsidianMoveToLink<CR>
  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> <buffer> <C-]> :VimsidianMoveToNextEntryInLinkStack<CR>
  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> <buffer> <C-t> :VimsidianMoveToPreviousEntryInLinkStack<CR>
  au BufNewFile,BufReadPost $VIMSIDIAN_PATH_PATTERN nn <silent> <buffer> S :VimsidianLinkStack<CR>
" ry ...
```
