### PR TITLE
Fix broken link for LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,4 +149,4 @@ make test
 
 ## LICENSE
 
-[WTFPL license - Do What The F\*ck You Want To Public License](./LICENSE.md)
+[WTFPL license - Do What The F\*ck You Want To Public License](./LICENSE)


### PR DESCRIPTION
Currently, in the README, the link to the LICENSE wrongly points to LICENSE.md